### PR TITLE
New nutri UI

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -45,6 +45,7 @@ translation:
     directions: "Directions"
     category: "Category"
     nutritional_information: "Nutritional Information"
+    nutri_table: "Nutrition facts per…"
     component_based: 'This is a <strong class="accent">component-based recipe</strong>.'
     search: "Search"
     search_placeholder: "for title or ingredients…"
@@ -80,7 +81,8 @@ translation:
     ingredients: "Ingrédients"
     directions: "Instructions"
     category: "Catégorie"
-    nutritional_information: "Informations nutritionnelles"
+    nutritional_information: "Nutrition"
+    nutri_table: "Valeurs nutritionnelles moyennes par…"
     component_based: 'Cette recette est composée <strong class="accent">d’une ou plusieurs préparations</strong>.'
     search: "Recherche"
     search_placeholder: "Par titre ou ingrédients…"

--- a/_data/fr/nutrients.yml
+++ b/_data/fr/nutrients.yml
@@ -1,61 +1,61 @@
 # See https://schema.org/NutritionInformation
 servingSize:
-  name: portion
+  name: Portion
   type: Text
   description: le nombre de portions.
   unit:
 calories:
-  name: calories
+  name: Énergie
   type: Energy
   description: Nombre de Calories.
   unit: kcal
 carbohydrateContent:
-  name: glucides
+  name: Glucides
   type: Mass
   description: Quantité de glucides en grammes.
   unit: g
 cholesterolContent:
-  name: cholestérol
+  name: Cholestérol
   type: Mass
   description: Quantité de cholestérol en milligrammes.
   unit: mg
 fatContent:
-  name: lipides
+  name: Matières grasses
   type: Mass
-  description: Quantité de lipides en grammes.
+  description: Quantité de matières grasses en grammes.
   unit: g
 fiberContent:
-  name: fibres
+  name: Fibres
   type: Mass
   description: Quantité de fibres en grammes.
   unit: g
 proteinContent:
-  name: protéines
+  name: Protéines
   type: Mass
   description: Quantité de protéines en grammes.
   unit: g
 saturatedFatContent:
-  name: saturés
+  name: Acides gras saturés
   type: Mass
   description: Quantité d’acides gras saturés en grammes.
   unit: g
 sodiumContent:
-  name: sel
+  name: Sel
   type: Mass
   description: Quantité de sel en grammes.
   unit: g
 sugarContent:
-  name: sucres
+  name: Sucres
   type: Mass
   description: Quantité de sucre en grammes.
   unit: g
 transFatContent:
-  name: trans
+  name: Acides trans
   type: Mass
   description: Quantité d’acides trans en grammes.
   unit: g
 unsaturatedFatContent:
-  name: insaturés
+  name: Acides gras insaturés
   type: Mass
   description: Quantité d’acides gras insaturés en grammes.
   unit: g

--- a/_includes/nutritional-information.html
+++ b/_includes/nutritional-information.html
@@ -10,20 +10,27 @@
 {% assign size = sizeVal | replace: "–", " " | split: " " %}
 {% assign divider = size[0] | default: 6 %}
 
-{% assign weight = 0 %}
 {% if page.nutrition['weight'] %}
-  {% assign weight = page.nutrition['weight'] | divided_by: divider | round: 0 %}
+  {% assign servingWeight = page.nutrition['weight'] | divided_by: divider | round: 0 %}
+  {% assign weightDivider = page.nutrition['weight'] | divided_by: 100.0 %}
 {% endif %}
 
-{% if weight > 0 %}
-  <h4 class="accent mt0 mb2 xs-center mt3">{{ site.translation[site.language].nutritional_information }} ({{ divider }} = {{weight}}&nbsp;g)</h4>
-{% else %}
-  <h4 class="accent mt0 mb2 xs-center mt3">{{ site.translation[site.language].nutritional_information }} ({{ divider }})</h4>
-{% endif %}
+<h4 class="accent mt0 mb2 xs-center mt3">{{ site.translation[site.language].nutritional_information }}</h4>
 
-<div class="flex flex-wrap" itemprop="nutrition" itemscope itemtype="http://schema.org/NutritionInformation">
+<div class="mr0 xs-mr0 sm-mr1 md-mr2 lg-mr2" itemprop="nutrition" itemscope itemtype="http://schema.org/NutritionInformation">
 {% assign nutrients = page.nutrition %}
-{% for nutrient in nutrients  %}
+<table class="nutrition-table">
+  <caption class="left-align bold">{{site.translation[site.language].nutri_table}}</caption>
+  <tr class="bg-gray white right-align bold">
+    <th></th>
+    {% if page.nutrition['weight'] %}
+    <td>100g</td>
+    <td>{{ site.data[site.language].nutrients['servingSize'].name }}: {{ divider }} ({{ servingWeight }}g)</td>
+    {% else %}
+    <td>{{ site.data[site.language].nutrients['servingSize'].name }}: {{ divider }}</td>
+    {% endif %}
+  </tr>
+  {% for nutrient in nutrients  %}
   {% if nutrient.first == 'servingSize' or nutrient.first == 'weight' %}{% continue %}{% endif %}
   {% assign itemprop = nutrient.first %}
   {% assign name = site.data[site.language].nutrients[itemprop].name %}
@@ -35,11 +42,20 @@
   
   {% assign value = nutrient.last | divided_by: divider | round: rounder %}
   {% assign unit = site.data[site.language].nutrients[itemprop].unit %}
-  <div  class="rounded center border border-1 border-gray sm-col sm-col-2 lg-col-2 mr1 mb1">
-    <h5 class="bg-gray white m0 p1 capitalize">{{ name  }}</h5>
-    <p itemprop="{{ itemprop }}">{{ value }} {{ unit }}</p>
-  </div>
+  <tr>
+    {% if nutrient.first == 'saturatedFatContent' or nutrient.first == 'sugarContent' %}
+    <th class="regular pl1">{{ name }}</th>
+    {% else %}
+    <th>{{ name }}</th>
+    {% endif %}
+    {% if page.nutrition['weight'] > 0 %}
+    {% assign weightValue = nutrient.last | divided_by: weightDivider | round: rounder %}
+    <td class="right-align" itemprop="{{ itemprop }}">{{ weightValue }} {{ unit }}</td>
+    {% endif %}
+    <td class="right-align" itemprop="{{ itemprop }}">{{ value }} {{ unit }}</td>
+  </tr>
   {% endfor %}
+</table>
 </div>
 <!-- end nutritional information -->
 {% endif %}

--- a/_includes/nutritional-information.html
+++ b/_includes/nutritional-information.html
@@ -25,7 +25,7 @@
     <th></th>
     {% if page.nutrition['weight'] %}
     <td class="valign-bottom">100g</td>
-    <td>{{ site.data[site.language].nutrients['servingSize'].name }}: {{ divider }} ({{ servingWeight }}g)</td>
+    <td>{{ site.data[site.language].nutrients['servingSize'].name }}: {{ servingWeight }}g ({{ divider }})</td>
     {% else %}
     <td>{{ site.data[site.language].nutrients['servingSize'].name }}: {{ divider }}</td>
     {% endif %}

--- a/_includes/nutritional-information.html
+++ b/_includes/nutritional-information.html
@@ -17,14 +17,14 @@
 
 <h4 class="accent mt0 mb2 xs-center mt3">{{ site.translation[site.language].nutritional_information }}</h4>
 
-<div class="mr0 xs-mr0 sm-mr1 md-mr2 lg-mr2" itemprop="nutrition" itemscope itemtype="http://schema.org/NutritionInformation">
+<div class="mr0 xs-mr1 sm-mr1 md-mr2 lg-mr2" itemprop="nutrition" itemscope itemtype="http://schema.org/NutritionInformation">
 {% assign nutrients = page.nutrition %}
 <table class="nutrition-table">
   <caption class="left-align bold">{{site.translation[site.language].nutri_table}}</caption>
   <tr class="bg-gray white right-align bold">
     <th></th>
     {% if page.nutrition['weight'] %}
-    <td>100g</td>
+    <td class="valign-bottom">100g</td>
     <td>{{ site.data[site.language].nutrients['servingSize'].name }}: {{ divider }} ({{ servingWeight }}g)</td>
     {% else %}
     <td>{{ site.data[site.language].nutrients['servingSize'].name }}: {{ divider }}</td>
@@ -50,9 +50,9 @@
     {% endif %}
     {% if page.nutrition['weight'] > 0 %}
     {% assign weightValue = nutrient.last | divided_by: weightDivider | round: rounder %}
-    <td class="right-align" itemprop="{{ itemprop }}">{{ weightValue }} {{ unit }}</td>
+    <td class="right-align" itemprop="{{ itemprop }}">{{ weightValue }}{{ unit }}</td>
     {% endif %}
-    <td class="right-align" itemprop="{{ itemprop }}">{{ value }} {{ unit }}</td>
+    <td class="right-align" itemprop="{{ itemprop }}">{{ value }}{{ unit }}</td>
   </tr>
   {% endfor %}
 </table>

--- a/_recipes/PB-brownie.md
+++ b/_recipes/PB-brownie.md
@@ -10,7 +10,7 @@ images:
     alt: "La texture et coulante voire gluante, et c'est quasiment impossible de ne pas obtenir le résultat escompté. Pour ajouter du croquant, on a utilisé des M&M’s Peanut dans cette version." 
 cuisines: [américaine]
 courses: [snack]
-tags: [gooey, 3 ingrédients]
+tags: [gooey, 4 ingrédients, M&M’s]
 collections: [brownie, pb, cupboard]
 diets: [Vegetarian, Vegan]
 

--- a/_recipes/cookie-dough-mm.md
+++ b/_recipes/cookie-dough-mm.md
@@ -10,7 +10,7 @@ images:
     alt: "Après, forcément, il faut s’attendre à une sensation différente du cookie cuit, raison pour laquelle certaines personnes détestent. On est vraiment sur un mélange cru qui n’offre du craquant que grâce aux M&M’s, qu’il faudra bien faire attention de ne pas trop abîmer en les incorporant."
 cuisines: [américaine]
 courses: [snack, dessert]
-tags: [cookie, sans cuisson, M&M’s]
+tags: [cookie, bouchée, sans cuisson, M&M’s]
 
 preptime: 25 min
 totaltime: 1 h

--- a/_recipes/cookie-dough-pistache.md
+++ b/_recipes/cookie-dough-pistache.md
@@ -10,7 +10,7 @@ images:
     alt: "Après, forcément, il faut s’attendre à une sensation différente du cookie cuit, raison pour laquelle certaines personnes détestent. On est vraiment sur un mélange cru qui n’offre de craquant qu’à travers les éclats de pistache."
 cuisines: [américaine]
 courses: [snack, dessert]
-tags: [cookie, sans cuisson]
+tags: [cookie, bouchée, sans cuisson]
 
 preptime: 25 min
 totaltime: 1 h

--- a/_recipes/cookie-dough.md
+++ b/_recipes/cookie-dough.md
@@ -10,7 +10,7 @@ images:
     alt: "Après, forcément, il faut s’attendre à une sensation différente du cookie cuit, raison pour laquelle certaines personnes détestent. On est vraiment sur un mélange cru qui n’offre aucun craquant."
 cuisines: [américaine]
 courses: [snack, dessert]
-tags: [cookie, sans cuisson]
+tags: [cookie, bouchée, sans cuisson]
 
 preptime: 25 min
 totaltime: 1 h

--- a/_recipes/cottage-apero.md
+++ b/_recipes/cottage-apero.md
@@ -7,7 +7,7 @@ images:
     path: cottage-apero/cottage-apero-1.jpg
 cuisines: [américaine]
 courses: [apéritif]
-tags: [sans cuisson]
+tags: [bouchée, sans cuisson]
 
 preptime: 10 min
 yield: 18 bouchées

--- a/_recipes/cottage-dough.md
+++ b/_recipes/cottage-dough.md
@@ -10,7 +10,7 @@ images:
     alt: "Pour une vraie expérience cookie dough, la consistance doit ressembler à la pâte à cookie après passage au frigo. Il faut donc pouvoir passer une cuillère à glace dedans sans forcer et former des boules. Pour une expérience plus onctueuse on peut néanmoins ajouter du lait."
 cuisines: [américaine]
 courses: [snack, dessert]
-tags: [cookie, sans cuisson, protéiné, récupération]
+tags: [cookie, bouchée, sans cuisson, protéiné, récupération]
 
 preptime: 10 min
 yield: 18 bouchées

--- a/css/bass.css
+++ b/css/bass.css
@@ -206,7 +206,7 @@ h6, .h6 { font-size: .75rem }
 .full-width { width: 100% }
 
 
-.bold    { font-weight: bold; font-weight: bold }
+.bold    { font-weight: bold; }
 .regular { font-weight: normal }
 .italic  { font-style: italic }
 .caps    { text-transform: uppercase; letter-spacing: .2em; }
@@ -915,7 +915,7 @@ hr {
 .field-light:focus {
   outline: none;
 /*  border-color: #007FFF; */
-  border-color #CB4E06;
+  border-color: #CB4E06;
   box-shadow: 0 0 0 2px rgba(0, 127, 255, 0.5);
 }
 

--- a/css/main.scss
+++ b/css/main.scss
@@ -196,6 +196,45 @@ li.slider-img {
 	padding: 0;
 }
 
+.nutrition-table {
+	font-size: 0.875rem;
+}
+
+.nutrition-table caption {
+	text-align: left !important;
+}
+
+.nutrition-table th {
+	border-right: 1px solid #aaa;
+}
+
+.nutrition-table th,
+.nutrition-table td {
+	padding: 0.125rem 0.25rem;
+	vertical-align: top !important;
+	border-bottom: 1px dotted #aaa;
+}
+
+.nutrition-table td {
+	text-align: right !important;
+	border-bottom: 1px dotted #aaa;
+}
+
+.nutrition-table tr:last-child th,
+.nutrition-table tr:last-child td {
+  border-bottom: 1px solid #aaa;
+}
+
+.nutrition-table td.valign-bottom {
+	vertical-align: bottom !important;
+}
+
 .pl1 {
-	padding-left: 0.5rem;
+	padding-left: 0.5rem !important;
+}
+
+@media screen and (min-width:40em) {
+	.pl1 {
+		padding-left: 1rem !important;
+	}
 }

--- a/css/main.scss
+++ b/css/main.scss
@@ -195,3 +195,7 @@ nav.main-nav .nav-item.active .nav-label{
 li.slider-img {
 	padding: 0;
 }
+
+.pl1 {
+	padding-left: 0.5rem;
+}


### PR DESCRIPTION
Présentation des valeurs nutritionnelles en tableau avec calcul par 100g et par portion.

Jekyll se sert de `nutrition.servingSize` et `nutrition.weight` dans le front matter YAML.

Si `nutrition.weight` est absent, il zappe la colonne. Si `nutrition.servingSize` est absent, il essaye d’aller piocher dans `yield`, et s’il ne trouve pas, utilise la valeur `6`  par défaut pour le calcul des portions.